### PR TITLE
Add support for ZMQ_ROUTER_MANDATORY

### DIFF
--- a/options/sockopts.xml
+++ b/options/sockopts.xml
@@ -154,6 +154,7 @@
         <option name="tcp_accept_filter" type="blob" mode="rw"/>
         <option name="delay_attach_on_connect" type="int" mode="rw"/>
         <option name="xpub_verbose" type="int" mode="rw"/>
+        <option name="router_mandatory" type="int" mode="w"/>
         <!--<option name="router_raw" type="int" mode="rw"/> -->
     </version>
     <version major="4" comparison="ZMQ_VERSION_MAJOR >= 4">
@@ -187,6 +188,7 @@
         <option name="tcp_accept_filter" type="blob" mode="rw"/>
         <option name="delay_attach_on_connect" type="int" mode="rw"/>
         <option name="xpub_verbose" type="int" mode="rw"/>
+        <option name="router_mandatory" type="int" mode="w"/>
         <option name="router_raw" type="int" mode="rw"/>
         <option name="ipv6" type="int" mode="rw"/>
         <option name="plain_server" type="int" mode="rw"/>

--- a/package.xml
+++ b/package.xml
@@ -100,6 +100,7 @@
       <file name="045-auth-allow-deny.phpt" role="test" />
       <file name="046-cert-apply.phpt" role="test" />
       <file name="047-auth-configure.phpt" role="test" />
+      <file name="bug_gh_156.phpt" role="test" />
       <file name="bug_gh_43.phpt" role="test" />
       <file name="bug_gh_49.phpt" role="test" />
       <file name="bug_gh_50.phpt" role="test" />

--- a/tests/bug_gh_156.phpt
+++ b/tests/bug_gh_156.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test for GitHub issue 156 (https://github.com/mkoppanen/php-zmq/issues/156)
+--DESCRIPTION--
+The ZMQ_ROUTER_MANDATORY socket option was introduced in ØMQ v3.2.1 but wasn't
+included in the appropriate sections of options/sockopts.xml.
+
+Test that the ZMQ_ROUTER_MANDATORY socket option can be set when using ØMQ
+v3.2.1 or higher.
+--SKIPIF--
+<?php
+
+require_once(__DIR__ . '/skipif.inc');
+
+if (!defined('\\ZMQ::SOCKOPT_ROUTER_MANDATORY')) {
+    die('skip');
+}
+
+--FILE--
+<?php
+
+$context = new ZMQContext();
+$socket = $context->getSocket(\ZMQ::SOCKET_ROUTER);
+$socket->setSockOpt(\ZMQ::SOCKOPT_ROUTER_MANDATORY, 1);
+
+echo "OK";
+
+--EXPECT--
+OK

--- a/zmq_sockopt.c
+++ b/zmq_sockopt.c
@@ -4122,6 +4122,19 @@ PHP_METHOD(zmqsocket, getsockopt)
 			RETURN_LONG(value);
 		}
 		break;
+		
+		case ZMQ_ROUTER_MANDATORY:
+		{
+			int value;
+
+			value_len = sizeof(int);
+			if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
+				zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno TSRMLS_CC, "Failed to get the option ZMQ::SOCKOPT_ROUTER_MANDATORY value: %s", zmq_strerror(errno));
+				return;
+			}
+			RETURN_LONG(value);
+		}
+		break;
 	
 
 		case ZMQ_FD:
@@ -4603,6 +4616,23 @@ PHP_METHOD(zmqsocket, setsockopt)
 		break;
 
 	
+
+		case ZMQ_ROUTER_MANDATORY:
+		{
+			int value;
+			convert_to_long(pz_value);
+			
+			value  = (int) Z_LVAL_P(pz_value);
+			status = zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int));
+			
+			if (status != 0) {
+				zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno TSRMLS_CC, "Failed to set socket ZMQ::SOCKOPT_ROUTER_MANDATORY option: %s", zmq_strerror(errno));
+				return;
+			}
+		}
+		break;
+
+	
 		
 		case ZMQ_HWM:
 		{
@@ -4706,6 +4736,8 @@ void php_zmq_register_sockopt_constants (zend_class_entry *php_zmq_sc_entry TSRM
 	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_DELAY_ATTACH_ON_CONNECT", ZMQ_DELAY_ATTACH_ON_CONNECT);
 			
 	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_XPUB_VERBOSE", ZMQ_XPUB_VERBOSE);
+			
+	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_ROUTER_MANDATORY", ZMQ_ROUTER_MANDATORY);
 			
 #undef PHP_ZMQ_REGISTER_SOCKOPT
 }
@@ -5096,6 +5128,19 @@ PHP_METHOD(zmqsocket, getsockopt)
 			value_len = sizeof(int);
 			if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
 				zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno TSRMLS_CC, "Failed to get the option ZMQ::SOCKOPT_XPUB_VERBOSE value: %s", zmq_strerror(errno));
+				return;
+			}
+			RETURN_LONG(value);
+		}
+		break;
+		
+		case ZMQ_ROUTER_MANDATORY:
+		{
+			int value;
+
+			value_len = sizeof(int);
+			if (zmq_getsockopt(intern->socket->z_socket, (int) key, &value, &value_len) != 0) {
+				zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno TSRMLS_CC, "Failed to get the option ZMQ::SOCKOPT_ROUTER_MANDATORY value: %s", zmq_strerror(errno));
 				return;
 			}
 			RETURN_LONG(value);
@@ -5765,6 +5810,23 @@ PHP_METHOD(zmqsocket, setsockopt)
 
 	
 
+		case ZMQ_ROUTER_MANDATORY:
+		{
+			int value;
+			convert_to_long(pz_value);
+			
+			value  = (int) Z_LVAL_P(pz_value);
+			status = zmq_setsockopt(intern->socket->z_socket, key, &value, sizeof(int));
+			
+			if (status != 0) {
+				zend_throw_exception_ex(php_zmq_socket_exception_sc_entry_get (), errno TSRMLS_CC, "Failed to set socket ZMQ::SOCKOPT_ROUTER_MANDATORY option: %s", zmq_strerror(errno));
+				return;
+			}
+		}
+		break;
+
+	
+
 		case ZMQ_ROUTER_RAW:
 		{
 			int value;
@@ -6087,6 +6149,8 @@ void php_zmq_register_sockopt_constants (zend_class_entry *php_zmq_sc_entry TSRM
 	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_DELAY_ATTACH_ON_CONNECT", ZMQ_DELAY_ATTACH_ON_CONNECT);
 			
 	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_XPUB_VERBOSE", ZMQ_XPUB_VERBOSE);
+			
+	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_ROUTER_MANDATORY", ZMQ_ROUTER_MANDATORY);
 			
 	PHP_ZMQ_REGISTER_SOCKOPT("SOCKOPT_ROUTER_RAW", ZMQ_ROUTER_RAW);
 			


### PR DESCRIPTION
The ZMQ_ROUTER_MANDATORY socket option [was introduced in ØMQ v3.2.1](https://github.com/zeromq/zeromq3-x/blob/v3.2.1/include/zmq.h#L245)
but wasn't included in the appropriate sections of options/sockopts.xml.