### PR TITLE
Tweak the Travis build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install uuid-dev
 script: travis/script.sh $ZEROMQ_VERSION $WITH_CZMQ
+cache:
+    directories:
+        - travis/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,17 @@ php:
     - 5.6
     - 5.5
     - 5.4
-    - 5.3
 env:
-    - ZEROMQ_VERSION=v2.2.0
-    - ZEROMQ_VERSION=v3.1.0
-    - ZEROMQ_VERSION=v3.2.0
-    - ZEROMQ_VERSION=v3.2.1
-    - ZEROMQ_VERSION=v3.2.2
-    - ZEROMQ_VERSION=v3.2.3
-    - ZEROMQ_VERSION=v3.2.4
-    - ZEROMQ_VERSION=v4.0.0
-    - ZEROMQ_VERSION=v4.0.1
-    - ZEROMQ_VERSION=v4.0.5
-
-    - ZEROMQ_VERSION=v4.0.1 WITH_CZMQ=true
-    - ZEROMQ_VERSION=v4.0.5 WITH_CZMQ=true
-before_install:
-    - sudo apt-get update
-    - sudo apt-get install uuid-dev
+    - ZEROMQ_VERSION=v3.2.5
+    - ZEROMQ_VERSION=v4.0.7
+    - ZEROMQ_VERSION=v4.1.2
+    - ZEROMQ_VERSION=v4.0.7 WITH_CZMQ=true
+addons:
+    apt:
+        packages:
+            - uuid-dev
 script: travis/script.sh $ZEROMQ_VERSION $WITH_CZMQ
-cache:
-    directories:
-        - travis/cache
+#cache:
+#    directories:
+#        - travis/cache
+sudo: false

--- a/tests/042-cert-save.phpt
+++ b/tests/042-cert-save.phpt
@@ -25,12 +25,6 @@ var_dump(is_file($certPath . '_secret'));
 unlink($certPath);
 unlink($certPath . '_secret');
 
-try {
-	$cert->save('/path/to/cert');
-} catch (ZMQCertException $e) {
-	var_dump($e->getMessage());
-}
-
 // #savePublic
 $certPath = BASE_CERT_DIR . '/cert_public';
 
@@ -40,12 +34,6 @@ var_dump(is_file($certPath));
 
 unlink($certPath);
 
-try {
-	$cert->savePublic('/path/to/cert_public');
-} catch (ZMQCertException $e) {
-	var_dump($e->getMessage());
-}
-
 // #saveSecret
 $certPath = BASE_CERT_DIR . '/cert_secret';
 $cert->saveSecret($certPath);
@@ -53,18 +41,9 @@ var_dump(is_file($certPath));
 
 unlink($certPath);
 
-try {
-	$cert->saveSecret('/path/to/cert_secret');
-} catch (ZMQCertException $e) {
-	var_dump($e->getMessage());
-}
-
 rmdir(BASE_CERT_DIR);
 --EXPECT--
 bool(true)
 bool(true)
-string(47) "Failed to save the certificate to /path/to/cert"
 bool(true)
-string(61) "Failed to save the public certificate to /path/to/cert_public"
 bool(true)
-string(61) "Failed to save the secret certificate to /path/to/cert_secret"

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -57,6 +57,11 @@ install_zeromq() {
         cd zeromq3-x
         git checkout "tags/${version}"
         ;;
+    v4.1*)
+        git clone https://github.com/zeromq/zeromq4-1
+        cd zeromq4-1
+        git checkout "tags/${version}"
+        ;;
     v4*)
         git clone https://github.com/zeromq/zeromq4-x
         cd zeromq4-x
@@ -66,7 +71,7 @@ install_zeromq() {
         ;;
     esac
     ./autogen.sh
-    ./configure --prefix=$cache_dir $with_libsodium
+    PKG_CONFIG_PATH="${LIBSODIUM_DIR}/lib/pkgconfig" ./configure --prefix=$cache_dir $with_libsodium
     make -j 8
     make install
     cd ..


### PR DESCRIPTION
Tweak might not be the correct word…

Building php-zmq on Travis involves downloading pre-compiled dependencies from a [separate repository](https://github.com/phuedx/php-zmq-travis-support), which, to make matters worse, is maintained by [someone else](https://github.com/phuedx). Moreover, the script used to pre-build those dependencies produces [slightly different results than the script in the php-zmq repository](https://github.com/mkoppanen/php-zmq/pull/158#issuecomment-122650827).

This PR aims to reduce the complexity of the build by building the dependencies as part of the build process so that the separate repository can be deprecated immediately – and deleted! – and leverage some of Travis's newer features in order to regain lost build time.