### PR TITLE
Make setsockopt properly check that values are greater than 0 for uint64_t options

### DIFF
--- a/options/generate.xslt
+++ b/options/generate.xslt
@@ -323,7 +323,7 @@ PHP_METHOD(zmqsocket, setsockopt)
 		{
 			<xsl:value-of select="$type"/> value;
 			convert_to_long(pz_value);
-			<xsl:if test="type = 'uint64_t'">
+			<xsl:if test="$type = 'uint64_t'">
 			if (Z_LVAL_P(pz_value) &lt; 0) {
 				zend_throw_exception(php_zmq_socket_exception_sc_entry_get (), "The option ZMQ::SOCKOPT_<xsl:value-of select="$raw-name"/> value must be zero or larger", PHP_ZMQ_INTERNAL_ERROR TSRMLS_CC);
 				return;


### PR DESCRIPTION
The XSLT transform had a minor typo that I noticed while I was re-writing the transform to port it to HHVM, this typo causes the check to ensure that the input value is greater than or equal to zero to never succeed, causing the check to never be generated.

This simply fixes the typo, it does not regenerate the generated file.