### PR TITLE
Fix build with old GCC

### DIFF
--- a/zmq_pollset.c
+++ b/zmq_pollset.c
@@ -38,7 +38,7 @@
 
 /* {{{ typedef struct _php_zmq_pollset 
 */
-typedef struct _php_zmq_pollset {
+struct _php_zmq_pollset {
 
 	zmq_pollitem_t *items;
 	zend_string **keys;
@@ -49,7 +49,7 @@ typedef struct _php_zmq_pollset {
 	size_t alloc_size;
 
 	zval errors;
-} php_zmq_pollset;
+};
 /* }}} */
 
 static


### PR DESCRIPTION
On RHEL.CentOS-6 (gcc 4.4)

     /builddir/build/BUILD/php70-php-pecl-zmq-1.1.3/NTS/zmq_pollset.c:52: error: redefinition of typedef 'php_zmq_pollset'
     /builddir/build/BUILD/php70-php-pecl-zmq-1.1.3/NTS/php_zmq_private.h:54: note: previous declaration of 'php_zmq_pollset' was here
