### PR TITLE
Fix API breaking changes for PHP 7.3

### DIFF
--- a/zmq.c
+++ b/zmq.c
@@ -235,7 +235,7 @@ php_zmq_context *php_zmq_context_get(zend_long io_threads, zend_bool is_persiste
 		le.type = php_zmq_context_list_entry();
 		le.ptr  = context;
 
-		GC_REFCOUNT(&le) = 1;
+		GC_SET_REFCOUNT(&le, 1);
 
 		/* plist_key is not a persistent allocated key, thus we use str_update here */
 		if (zend_hash_str_update_mem(&EG(persistent_list), plist_key->val, plist_key->len, &le, sizeof(le)) == NULL) {
@@ -535,7 +535,7 @@ void php_zmq_socket_store(php_zmq_socket *zmq_sock_p, zend_long type, zend_strin
 	le.type = php_zmq_socket_list_entry();
 	le.ptr  = zmq_sock_p;
 
-	GC_REFCOUNT(&le) = 1;
+	GC_SET_REFCOUNT(&le, 1);
 
 	plist_key = php_zmq_socket_plist_key(type, persistent_id, use_shared_ctx);
 


### PR DESCRIPTION
For some reason PHP made API breaking changes in a minor release.

See: https://github.com/php/php-src/commit/49ea143bbd8d0bfcd393d0b5308a5d7833fc087c